### PR TITLE
Adding a true_timestamp metadata

### DIFF
--- a/lib/gn/tracker.rb
+++ b/lib/gn/tracker.rb
@@ -27,7 +27,8 @@ module Gn
       @logger.info LogStash::Event.new(
         message: message.to_json,
         application: application,
-        schema: schema
+        schema: schema,
+        true_timestamp: Time.now
       )
     end
 


### PR DESCRIPTION
Isso permite o tracking do timestamp exato, no momento da criação do evento
