### PR TITLE
Using time in millis

### DIFF
--- a/lib/gn/tracker.rb
+++ b/lib/gn/tracker.rb
@@ -28,7 +28,7 @@ module Gn
         message: message.to_json,
         application: application,
         schema: schema,
-        true_timestamp: Time.now
+        true_timestamp: (Time.now.to_i * 1000)
       )
     end
 


### PR DESCRIPTION
Usando tempo em milissegundos, para que o true_timestamp do Snowplow funcione.