### PR TITLE
Adiciona o Drone CI ao projeto

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
 - name: test
   image: ruby:2.6.3
   commands:
-  - bundle install --with test --deployment --jobs=4 --path vendor/bundle
+  - bundle install --with test --jobs=4 --path vendor/bundle
   - bundle exec rspec spec
 
 ...


### PR DESCRIPTION
A adição do Drone é necessária já que precisamos validar se o código está passando nos teste antes de mergear e principalmente quando temos PRs do dependabot já saberemos se passam nos testes ou não